### PR TITLE
chore: CI CD

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,98 @@
+name: "Terraform"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  TF_DIR: ./environments/prod
+  AWS_ACCESS_KEY_ID:  ${{secrets.AWS_ACCESS_KEY_ID}}
+  AWS_SECRET_ACCESS_KEY:  ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  AWS_DEFAULT_REGION: eu-central-1
+
+jobs:
+  terraform:
+    name: "Terraform"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Terraform Format
+        id: fmt
+        run: terraform fmt -check
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+        working-directory: ${{ env.TF_DIR }}
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Setup Terraform Linter
+        uses: terraform-linters/setup-tflint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Terraform Linter plugins
+        run: tflint --init
+
+      - name: Terraform Linter
+        id:  tflint
+        run: tflint -f compact
+
+      - name: Run Checkov action
+        id: checkov
+        uses: bridgecrewio/checkov-action@master
+        with:
+          quiet: true
+          framework: terraform
+
+      - name: Terraform Plan
+        id: plan
+        if: github.event_name == 'pull_request'
+        run: terraform plan -no-color
+        continue-on-error: true
+        working-directory: ${{ env.TF_DIR }}
+
+      - uses: actions/github-script@0.9.0
+        if: github.event_name == 'pull_request'
+        env:
+          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Linter ☑️\`${{ steps.tflint.outcome }}\`
+            #### Checkov 👮‍️\`${{ steps.checkov.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+            <details><summary>Show Plan</summary>
+            \`\`\`\n
+            ${process.env.PLAN}
+            \`\`\`
+            </details>
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform apply -auto-approve
+        working-directory: ${{ env.TF_DIR }}

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ terraform plan
 terraform apply
 ```
 
+## Deployment
+
+Changes are deployed to AWS after push to branch `main` (when pull request is merged).
+
 ## Licence
 
 [GNU General Public License v3.0](LICENSE)

--- a/modules/cdn_with_s3_bucket/bucket.tf
+++ b/modules/cdn_with_s3_bucket/bucket.tf
@@ -25,11 +25,16 @@ data "aws_iam_policy_document" "s3_origin" {
 }
 
 resource "aws_s3_bucket" "default" {
-  #checkov:skip=CKV_AWS_21:Versioning is disabled to save money
-  #checkov:skip=CKV_AWS_144:Cross-region replication is disabled to save money
   #checkov:skip=CKV_AWS_18:Access logging is disabled to save money
   #checkov:skip=CKV_AWS_19:Data are encrypted - outdated rule
+  #checkov:skip=CKV_AWS_21:Versioning is disabled to save money
+  #checkov:skip=CKV_AWS_144:Cross-region replication is disabled to save money
   #checkov:skip=CKV_AWS_145:Data are encrypted - outdated rule
+  #checkov:skip=CKV2_AWS_37:Versioning is disabled to save money
+  #checkov:skip=CKV2_AWS_38:Website (redirect) require that
+  #checkov:skip=CKV2_AWS_39:Website (redirect) require that
+  #checkov:skip=CKV2_AWS_40:Data are encrypted
+  #checkov:skip=CKV2_AWS_41:Access logging is disabled to save money
 
   bucket = var.s3_bucket_name
 }

--- a/modules/redirect/s3.tf
+++ b/modules/redirect/s3.tf
@@ -1,11 +1,13 @@
 resource "aws_s3_bucket" "default" {
-  #checkov:skip=CKV_AWS_21:Versioning is disabled to save money
-  #checkov:skip=CKV_AWS_144:Cross-region replication is disabled to save money
   #checkov:skip=CKV_AWS_18:Access logging is disabled to save money
   #checkov:skip=CKV_AWS_19:Data are encrypted - outdated rule
+  #checkov:skip=CKV_AWS_144:Cross-region replication is disabled to save money
   #checkov:skip=CKV_AWS_145:Data are encrypted - outdated rule
-  #checkov:skip=CKV_AWS_20:Bucket should be public read to enable redirect to www. domain
+  #checkov:skip=CKV_AWS_21:Versioning is disabled to save money
   #checkov:skip=CKV2_AWS_6:Public access can't be blocked to enable redirect
+  #checkov:skip=CKV2_AWS_37:Versioning is disabled to save money
+  #checkov:skip=CKV2_AWS_40:Data are encrypted
+  #checkov:skip=CKV2_AWS_41:Access logging is disabled to save money
 
   bucket = var.domain_name
 }


### PR DESCRIPTION
Inspired by

* [Automate Terraform with GitHub Actions](https://learn.hashicorp.com/tutorials/terraform/github-actions)
* [hashicorp/learn-terraform-github-actions](https://github.com/hashicorp/learn-terraform-github-actions)

Pre-commit is not used by GitHub actions for now - I'm curious about the benefits of usage actions, which probably are better integrated with GH. It could be changed in the future to keep checks compatible.

After PR code is validated and `terraform plan` is run. Results are added as comments to PR.

After merging to `main` script `terraform apply` is run - it means changes applied from local envs could be overwritten(!)
