### PR TITLE
ci: fix ci, upgrade tflint aws plugin

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Setup Terraform Linter
         uses: terraform-linters/setup-tflint@v1
         with:
+          tflint_version: 0.35.0
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Terraform Linter plugins

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Setup Terraform Linter
         uses: terraform-linters/setup-tflint@v1
         with:
-          tflint_version: 0.35.0
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Terraform Linter plugins

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,5 +1,5 @@
 plugin "aws" {
   enabled = true
-  version = "0.12.0"
+  version = "0.13.2"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }

--- a/modules/cdn_with_s3_bucket/bucket.tf
+++ b/modules/cdn_with_s3_bucket/bucket.tf
@@ -27,7 +27,9 @@ data "aws_iam_policy_document" "s3_origin" {
 resource "aws_s3_bucket" "default" {
   #checkov:skip=CKV_AWS_18:Access logging is disabled to save money
   #checkov:skip=CKV_AWS_19:Data are encrypted - outdated rule
+  #checkov:skip=CKV_AWS_20:ACL is set to private, the rule is broken
   #checkov:skip=CKV_AWS_21:Versioning is disabled to save money
+  #checkov:skip=CKV_AWS_57:ACL is set to private, the rule is broken
   #checkov:skip=CKV_AWS_144:Cross-region replication is disabled to save money
   #checkov:skip=CKV_AWS_145:Data are encrypted - outdated rule
   #checkov:skip=CKV2_AWS_37:Versioning is disabled to save money

--- a/modules/redirect/s3.tf
+++ b/modules/redirect/s3.tf
@@ -1,9 +1,11 @@
 resource "aws_s3_bucket" "default" {
   #checkov:skip=CKV_AWS_18:Access logging is disabled to save money
   #checkov:skip=CKV_AWS_19:Data are encrypted - outdated rule
+  #checkov:skip=CKV_AWS_20:Public access can't be blocked to enable redirect
+  #checkov:skip=CKV_AWS_21:Versioning is disabled to save money
+  #checkov:skip=CKV_AWS_57:public-read ACL allows only public read. The rule is broken.
   #checkov:skip=CKV_AWS_144:Cross-region replication is disabled to save money
   #checkov:skip=CKV_AWS_145:Data are encrypted - outdated rule
-  #checkov:skip=CKV_AWS_21:Versioning is disabled to save money
   #checkov:skip=CKV2_AWS_6:Public access can't be blocked to enable redirect
   #checkov:skip=CKV2_AWS_37:Versioning is disabled to save money
   #checkov:skip=CKV2_AWS_40:Data are encrypted


### PR DESCRIPTION
The build is failing because of incompatible versions of tflint and aws plugin for tflint. 

This should help.